### PR TITLE
update dependencies in notebook

### DIFF
--- a/notebooks/binary_clock.livemd
+++ b/notebooks/binary_clock.livemd
@@ -2,7 +2,8 @@
 
 ```elixir
 Mix.install([
-  {:circuits_spi, "~> 1.3"}
+  {:circuits_spi, "~> 2.0 or ~> 1.0"},
+  {:kino, "~> 0.12.2"}
 ])
 ```
 
@@ -111,8 +112,9 @@ Here's an animation of the clock. It starts at a random time and runs way faster
 
 ```elixir
 starting_time = :rand.uniform(86400)
+interval_ms = 50
 
-Kino.animate(50, starting_time, fn seconds ->
+Kino.animate(interval_ms, starting_time, fn _, seconds ->
   h = seconds |> div(3600)
   m = seconds |> div(60) |> rem(60)
   s = seconds |> rem(60)


### PR DESCRIPTION
### Description

The interface of Kino.animate/3 has been changed since this notebook was written. Let's update it.

Since Kino introduces incompatible changes every now and then, it is safe to lock its version.

On the other hand, Circuits.SPI seems to work well regardless of its version.

### Changes

- specify dependency versions
- adjust the code that uses `Kino.animate/3`

### Notes

- I thought using `interval_ms` might help the user understand what that value means while we could do without it