### PR TITLE
explain about LSB-first error in notebook

### DIFF
--- a/notebooks/binary_clock.livemd
+++ b/notebooks/binary_clock.livemd
@@ -37,6 +37,10 @@ alias Circuits.SPI
 {:ok, spi} = SPI.open("spidev0.0", mode: 3, lsb_first: true)
 ```
 
+The error message `unsupported mode bits 8` might be printed due to hardware
+that doesn't support the LBS-first mode, which can be ignored since
+Circuits.SPI handles it automatically.
+
 ## SPI communication
 
 The next step is to send data to the TM1620 to make it turn on an LED. The flow chart on page 7 of the datasheet shows how to do this:


### PR DESCRIPTION
### Issue

An error is printed to standard error by Linux Kernel when hardware doesn't support the LSB-first mode. It is benign in our context since Circuits.SPI handles it automatically; however, currently there's no way of fixing this since Linux Kernel doesn't have an API to check support for the LSB first mode without printing that error message. The way that Linux Kernel figures out whether the LSB first mode is supported prints that error message.

![nerves-binary-clock-livebook-rpi4](https://github.com/fhunleth/binary_clock/assets/7563926/a53627ff-f9f5-4d1a-8473-39db532f21af)

### Solution

As a workaround, we want to at least inform users that the error in question can be ignored. It can be done in our Livebook notebook.

### Environment

- Mix target: `rpi0`, `rpi4`
- Mix project: [Nerves Livebook v0.12.1](https://github.com/nerves-livebook/nerves_livebook/tree/v0.12.1)
- circuits_spi: "2.0.2"
- nerves_system_rpi0: "1.25.1"
- nerves_system_rpi4: "1.25.1"

### Notes

- As a next step, we may want to do something similar in the documentation of Circuits.SPI.
